### PR TITLE
Add call-to-action section on homepage

### DIFF
--- a/content/pages/index.md
+++ b/content/pages/index.md
@@ -49,6 +49,46 @@ sections:
           - pl-6 md:pl-16
           - pb-16
           - pr-6 md:pr-16
+  - type: GenericSection
+    title:
+      text: Not sure where to start?
+      color: text-dark
+      type: TitleBlock
+      styles:
+        self:
+          textAlign: center
+    subtitle: Talk to an engineer. Plan your path.
+    subtitleStyles:
+      self:
+        textAlign: center
+    actions:
+      - label: Book My Free Call
+        url: https://calendly.com/elysiumcyber/intro
+        showIcon: true
+        icon: arrowRight
+        iconPosition: right
+        style: primary
+        type: Button
+        styles:
+          self:
+            justifyContent: center
+    colors: bg-gray-50 text-dark
+    styles:
+      self:
+        display: flex
+        flexDirection: col
+        justifyContent: center
+        alignItems: center
+        textAlign: center
+        padding:
+          - pt-14
+          - pb-14
+          - pl-6 md:pl-16
+          - pr-6 md:pr-16
+        maxWidth:
+          - max-w-screen-md
+        margin:
+          - mx-auto
   - type: FeaturedItemsSection
     title:
       text: Credible. Listable. Valuable.


### PR DESCRIPTION
## Summary
- add a CTA section encouraging users to book a call
- move it above the resume-ready feature section

## Testing
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_685072b065008322945ead0a7f1d433d