### PR TITLE
Add call-to-action footer block and polish hero

### DIFF
--- a/content/data/footer.json
+++ b/content/data/footer.json
@@ -4,7 +4,7 @@
         "altText": "Logo light",
         "type": "ImageBlock"
     },
-    "text": "The bridge between ambition and opportunity.",
+    "text": "<span class=\"text-gray-400 text-sm\">Real cybersecurity internships. No permission needed.</span>",
     "primaryLinks": {
         "title": "Product",
         "links": [

--- a/content/pages/index.md
+++ b/content/pages/index.md
@@ -7,7 +7,13 @@ sections:
       text: Real Cybersecurity Work. On Your Resume.
       color: text-dark
       type: TitleBlock
+      className: text-4xl md:text-5xl font-bold
     subtitle: Build resume-ready skills with mentorship and real experience.
+    subtitleStyles:
+      self:
+        margin:
+          top: 4
+          bottom: 6
     text: >
       This isn’t a course. It’s an internship — designed for you. Build real cybersecurity projects, get mentored by an engineer, and list “Cybersecurity Intern” on your resume with confidence.
     actions:
@@ -41,6 +47,11 @@ sections:
     elementId: ''
     colors: bg-light-fg-dark
     styles:
+      text:
+        color: text-gray-700
+        fontSize: large
+        margin:
+          top: 0
       self:
         alignItems: center
         flexDirection: col md:row
@@ -67,7 +78,8 @@ sections:
           Learn the exact skills companies look for in entry-level cloud security roles.
         actions: []
         elementId: null
-        colors: bg-neutralAlt-fg-dark
+        colors: bg-light-fg-dark
+        className: shadow-md hover:shadow-lg transition
         styles:
           self:
             padding:
@@ -75,7 +87,7 @@ sections:
               - pl-6 md:pl-8
               - pb-8
               - pr-6 md:pr-8
-            borderRadius: x-large
+            borderRadius: large
             flexDirection: col md:row
             justifyContent: center
             textAlign: left
@@ -98,7 +110,8 @@ sections:
           elementId: ''
           type: ImageBlock
         actions: []
-        colors: bg-neutralAlt-fg-dark
+        colors: bg-light-fg-dark
+        className: shadow-md hover:shadow-lg transition
         styles:
           self:
             padding:
@@ -106,7 +119,7 @@ sections:
               - pl-6 md:pl-8
               - pb-8
               - pr-6 md:pr-8
-            borderRadius: x-large
+            borderRadius: large
             flexDirection: col md:row
             textAlign: left
             justifyContent: center
@@ -121,7 +134,8 @@ sections:
           elementId: ''
           type: ImageBlock
         actions: []
-        colors: bg-neutralAlt-fg-dark
+        colors: bg-light-fg-dark
+        className: shadow-md hover:shadow-lg transition
         styles:
           self:
             padding:
@@ -129,7 +143,7 @@ sections:
               - pl-6 md:pl-8
               - pb-8
               - pr-6 md:pr-8
-            borderRadius: x-large
+            borderRadius: large
             flexDirection: col md:row
         type: FeaturedItem
     actions:
@@ -162,9 +176,57 @@ sections:
         justifyContent: center
       subtitle:
         textAlign: center
-seo:
-  metaTitle: Elysium Cyber
-  metaDescription: 
+  - type: GenericSection
+    title:
+      text: Not sure where to start?
+      color: text-dark
+      type: TitleBlock
+      styles:
+        self:
+          textAlign: center
+          fontSize: xxx-large
+          fontWeight: 700
+          margin:
+            bottom: 8
+    subtitle: Talk to an engineer. Plan your path.
+    subtitleStyles:
+      self:
+        textAlign: center
+        color: text-gray-700
+        margin:
+          bottom: 24
+    actions:
+      - label: Book My Free Call
+        url: https://calendly.com/elysiumcyber/intro
+        showIcon: true
+        icon: arrowRight
+        iconPosition: right
+        className: "bg-black text-white px-6 py-3 rounded-md hover:shadow-lg transition mx-auto block w-fit"
+        style: primary
+        type: Button
+        styles:
+          self:
+            justifyContent: center
+    colors: bg-gray-50 text-dark
+    styles:
+      self:
+        display: flex
+        flexDirection: col
+        justifyContent: center
+        alignItems: center
+        textAlign: center
+        padding:
+          - pt-14
+          - pb-14
+          - pl-6 md:pl-16
+          - pr-6 md:pr-16
+        maxWidth:
+          - max-w-screen-md
+        margin:
+          - mx-auto
+  seo:
+    metaTitle: Elysium Cyber
+  metaDescription: Elysium Cyber gives you hands-on cybersecurity experience with mentorship and real projects—so you can finally list something real on your resume.
   socialImage: /images/main-hero.jpg
   type: Seo
 type: PageLayout

--- a/src/components/sections/FeaturedItemsSection/FeaturedItem/index.tsx
+++ b/src/components/sections/FeaturedItemsSection/FeaturedItem/index.tsx
@@ -7,7 +7,7 @@ import Action from '../../../atoms/Action';
 import ImageBlock from '../../../blocks/ImageBlock';
 
 export default function FeaturedItem(props) {
-    const { elementId, title, tagline, subtitle, text, image, actions = [], colors = 'bg-light-fg-dark', styles = {}, hasSectionTitle } = props;
+    const { elementId, title, tagline, subtitle, text, image, actions = [], colors = 'bg-light-fg-dark', styles = {}, hasSectionTitle, className } = props;
     const fieldPath = props['data-sb-field-path'];
     const TitleTag = hasSectionTitle ? 'h3' : 'h2';
     const flexDirection = styles?.self?.flexDirection ?? 'col';
@@ -20,6 +20,7 @@ export default function FeaturedItem(props) {
             className={classNames(
                 'sb-card',
                 colors,
+                className,
                 styles?.self?.margin ? mapStyles({ margin: styles?.self?.margin }) : undefined,
                 styles?.self?.padding ? mapStyles({ padding: styles?.self?.padding }) : undefined,
                 styles?.self?.borderWidth && styles?.self?.borderWidth !== 0 && styles?.self?.borderStyle !== 'none'

--- a/src/components/sections/GenericSection/index.tsx
+++ b/src/components/sections/GenericSection/index.tsx
@@ -49,7 +49,7 @@ export default function GenericSection(props) {
                         {title && (
                             <TitleBlock
                                 {...title}
-                                className={classNames({ 'mt-4': badge?.label })}
+                                className={classNames(title?.className, { 'mt-4': badge?.label })}
                                 {...(enableAnnotations && { 'data-sb-field-path': '.title' })}
                             />
                         )}
@@ -66,9 +66,16 @@ export default function GenericSection(props) {
                         {text && (
                             <Markdown
                                 options={{ forceBlock: true, forceWrapper: true }}
-                                className={classNames('sb-markdown', 'sm:text-lg', styles?.text ? mapStyles(styles?.text) : undefined, {
-                                    'mt-6': badge?.label || title?.text || subtitle
-                                })}
+                                className={classNames(
+                                    'sb-markdown',
+                                    'sm:text-lg',
+                                    styles?.text ? mapStyles(styles?.text) : undefined,
+                                    {
+                                        'mt-6':
+                                            (badge?.label || title?.text || subtitle) &&
+                                            !(styles?.text?.margin && 'top' in styles.text.margin)
+                                    }
+                                )}
                                 {...(enableAnnotations && { 'data-sb-field-path': '.text' })}
                             >
                                 {text}


### PR DESCRIPTION
## Summary
- boost hero typography and spacing
- move booking CTA to the bottom of the homepage
- restyle feature cards with white backgrounds and shadows
- tweak footer tagline wording and contrast
- update homepage meta description

## Testing
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_685072b065008322945ead0a7f1d433d