### PR TITLE
Center subtitles and soften page background

### DIFF
--- a/content/pages/works.md
+++ b/content/pages/works.md
@@ -39,9 +39,6 @@ sections:
         self:
           textAlign: center
     subtitle: Speak with an engineer. Plan your path.
-    subtitleStyles:
-      self:
-        textAlign: center
     actions:
       - label: Book My Free Call
         url: https://calendly.com/elysiumcyber/intro
@@ -55,6 +52,8 @@ sections:
             justifyContent: center
     colors: bg-neutral-fg-dark
     styles:
+      subtitle:
+        textAlign: center
       self:
         display: flex
         flexDirection: col
@@ -81,9 +80,6 @@ sections:
         self:
           textAlign: center
     subtitle: Three simple steps. Real outcomes.
-    subtitleStyles:
-      self:
-        textAlign: center
     items:
       - title: "Step 1: Enroll & Choose Your Track"
         subtitle: Start Strong
@@ -153,6 +149,8 @@ sections:
     variant: three-col-grid
     colors: bg-neutral-fg-dark
     styles:
+      subtitle:
+        textAlign: center
       self:
         textAlign: center
         alignItems: center

--- a/src/components/layouts/DefaultBaseLayout/index.tsx
+++ b/src/components/layouts/DefaultBaseLayout/index.tsx
@@ -10,7 +10,7 @@ export default function DefaultBaseLayout(props) {
 
     return (
         <div className={classNames('sb-page', pageMeta.pageCssClasses)} {...(enableAnnotations && { 'data-sb-object-id': pageMeta.id })}>
-            <div className="sb-base sb-default-base-layout">
+            <div className="sb-base sb-default-base-layout bg-neutral">
                 {site.header && <Header {...site.header} enableAnnotations={enableAnnotations} />}
                 {props.children}
                 {site.footer && <Footer {...site.footer} enableAnnotations={enableAnnotations} />}


### PR DESCRIPTION
## Summary
- ensure GenericSection subtitle styles apply correctly on works page
- set a subtle gray background for the default layout

## Testing
- `npm run build` *(fails: `next: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6850874ac39c8322a14fa1b81e165001