### PR TITLE
Add Skill Tracks page and update navigation

### DIFF
--- a/content/data/header.json
+++ b/content/data/header.json
@@ -19,9 +19,9 @@
             "type": "Link"
         },
         {
-            "label": "Blog",
-            "altText": "Blog",
-            "url": "/blog",
+            "label": "Skill Tracks",
+            "altText": "Skill Tracks page",
+            "url": "/skill-tracks",
             "icon": "arrowRight",
             "iconPosition": "right",
             "style": "secondary",

--- a/src/pages/skill-tracks.js
+++ b/src/pages/skill-tracks.js
@@ -1,0 +1,73 @@
+import Head from 'next/head';
+import Link from 'next/link';
+
+export default function SkillTracks() {
+  const tracks = [
+    {
+      title: 'Cloud Security',
+      summary: [
+        'Secure AWS S3 buckets',
+        'Manage IAM roles',
+        'Detect & fix cloud misconfigurations'
+      ],
+      href: '/tracks/cloud-security'
+    },
+    {
+      title: 'Security Scripting',
+      summary: [
+        'Python & Bash scripting',
+        'Automate security tasks',
+        'Parse logs & detect anomalies'
+      ],
+      href: '/tracks/security-scripting'
+    },
+    {
+      title: 'Compliance & Risk',
+      summary: [
+        'Work with frameworks (NIST, CIS, SOC 2)',
+        'Perform risk assessments',
+        'Understand audits & documentation'
+      ],
+      href: '/tracks/compliance-risk'
+    }
+  ];
+  return (
+    <>
+      <Head>
+        <title>Skill Tracks - Elysium Cyber</title>
+      </Head>
+      <main className="min-h-screen bg-gray-900 text-gray-100 font-sans">
+        <section className="py-20 px-4 text-center">
+          <h1 className="text-4xl font-bold text-cyan-400">Elysium Cyber</h1>
+          <p className="mt-4 text-xl font-medium">
+            Real cybersecurity experience. Structured. Listable. Trusted.
+          </p>
+          <p className="mt-6 text-lg">
+            Choose your skill track below to start building real-world cybersecurity experience.
+          </p>
+        </section>
+        <section className="px-4 pb-20">
+          <div className="mx-auto max-w-5xl grid gap-6 md:grid-cols-3">
+            {tracks.map((track) => (
+              <Link key={track.title} href={track.href} className="group">
+                <div className="bg-gray-800 rounded-lg p-6 h-full shadow transition transform group-hover:-translate-y-1 group-hover:shadow-xl group-hover:scale-105">
+                  <h2 className="text-2xl font-semibold text-cyan-400 mb-4">
+                    {track.title}
+                  </h2>
+                  <ul className="space-y-1 text-left text-gray-300">
+                    {track.summary.map((item) => (
+                      <li key={item}>• {item}</li>
+                    ))}
+                  </ul>
+                </div>
+              </Link>
+            ))}
+          </div>
+        </section>
+        <footer className="text-center py-4 text-sm text-gray-400 border-t border-gray-700">
+          © 2025 Elysium Cyber. All rights reserved.
+        </footer>
+      </main>
+    </>
+  );
+}

--- a/src/pages/tracks/cloud-security.js
+++ b/src/pages/tracks/cloud-security.js
@@ -1,0 +1,7 @@
+export default function CloudSecurity() {
+  return (
+    <main className="min-h-screen flex items-center justify-center bg-gray-900 text-gray-100">
+      <h1 className="text-3xl font-semibold">Cloud Security Track Placeholder</h1>
+    </main>
+  );
+}

--- a/src/pages/tracks/compliance-risk.js
+++ b/src/pages/tracks/compliance-risk.js
@@ -1,0 +1,7 @@
+export default function ComplianceRisk() {
+  return (
+    <main className="min-h-screen flex items-center justify-center bg-gray-900 text-gray-100">
+      <h1 className="text-3xl font-semibold">Compliance & Risk Track Placeholder</h1>
+    </main>
+  );
+}

--- a/src/pages/tracks/security-scripting.js
+++ b/src/pages/tracks/security-scripting.js
@@ -1,0 +1,7 @@
+export default function SecurityScripting() {
+  return (
+    <main className="min-h-screen flex items-center justify-center bg-gray-900 text-gray-100">
+      <h1 className="text-3xl font-semibold">Security Scripting Track Placeholder</h1>
+    </main>
+  );
+}


### PR DESCRIPTION
## Summary
- replace Blog link with Skill Tracks in site header
- create a new landing page at `/skill-tracks`
- add placeholder pages for individual tracks

## Testing
- `npm run build` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_687059a552908322867750ee6d0a2548